### PR TITLE
normalized canonical

### DIFF
--- a/label_inspector/analysis/label_analysis.py
+++ b/label_inspector/analysis/label_analysis.py
@@ -202,7 +202,7 @@ class LabelAnalysis(AnalysisBase):
         return ''.join(canonicals)
 
     @field
-    def canonical_confusable_label(self) -> Optional[str]:
+    def normalized_canonical_label(self) -> Optional[str]:
         """
         Input label where all confusables are replaced
         with their canonicals and run through ENSIP normalization.
@@ -211,31 +211,26 @@ class LabelAnalysis(AnalysisBase):
         * at least one confusable does not have a canonical
         * result cannot be normalized
         """
-        if self.confusable_count == 0:
+        canonical_label = self.canonical_label
+        if canonical_label is None:
             return None
         try:
-            canonical_label = self.canonical_label
-            if canonical_label is None:
-                return None
             return ens_normalize(canonical_label)
         except DisallowedSequence:
             return None
 
     @field
-    def beautiful_canonical_confusable_label(self) -> Optional[str]:
+    def beautiful_canonical_label(self) -> Optional[str]:
         """
         ENSIP beautified `canonical_confusable_label`.
         Is `null` if `canonical_confusable_label` is `null`.
         """
-        canonical_label = self.canonical_confusable_label
+        canonical_label = self.canonical_label
         if canonical_label is None:
             return None
-
         try:
-            beautiful = ens_beautify(canonical_label)
-            return beautiful
+            return ens_beautify(canonical_label)
         except DisallowedSequence:
-            # should never happen as canonical_confusable_label is already normalized
             return None
 
     @field

--- a/label_inspector/models.py
+++ b/label_inspector/models.py
@@ -167,14 +167,13 @@ class InspectorResultBase(BaseModel):
                     'Is `null` if:\n'
                     '* at least one confusable does not have a canonical')
 
-    canonical_confusable_label: Optional[str] = Field(
+    normalized_canonical_label: Optional[str] = Field(
         description='Input label where all confusables are replaced with their canonicals and run through ENSIP-15 normalization.\n'
                     'Is `null` if:\n'
-                    '* input label is not confusable\n'
                     '* at least one confusable does not have a canonical\n'
                     '* result contains disallowed characters and cannot be normalized')
 
-    beautiful_canonical_confusable_label: Optional[str] = Field(
+    beautiful_canonical_label: Optional[str] = Field(
         description='Beautified version of `canonical_confusable_label`. Is `null` if `canonical_confusable_label` is null.')
 
     dns_hostname_support: bool = Field(

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -36,8 +36,8 @@ BASE_RESPONSE_FIELDS = [
     'punycode_compatibility',
     'punycode_encoding',
     'canonical_label',
-    'canonical_confusable_label',
-    'beautiful_canonical_confusable_label',
+    'normalized_canonical_label',
+    'beautiful_canonical_label',
     'font_support_all_os',
 ]
 

--- a/tests/test_inspector.py
+++ b/tests/test_inspector.py
@@ -156,7 +156,7 @@ def test_inspector_grapheme_label(analyse_label):
 @pytest.mark.parametrize(
     'input_label, normalized_input, expected_canonical_label, expected_beautiful_canonical_label',
     [
-        ('pure-words', True, None, None),  # no confusables
+        ('pure-words', True, 'pure-words', 'pure-words'),  # no confusables
         ('🄓ire', False, None, None),  # not normalized input
         ('yés', True, 'yes', 'yes'),  # "e" has the canonical version
         ('yéś', True, 'yes', 'yes'),  # both "Ŷ" and "Ś" have canonical version
@@ -175,11 +175,11 @@ def test_canonical_label(analyse_label,
                          expected_beautiful_canonical_label: str):
     result = analyse_label(input_label)
     if normalized_input:
-        assert result['canonical_confusable_label'] == expected_canonical_label
-        assert result['beautiful_canonical_confusable_label'] == expected_beautiful_canonical_label
+        assert result['normalized_canonical_label'] == expected_canonical_label
+        assert result['beautiful_canonical_label'] == expected_beautiful_canonical_label
     else:
-        assert result['canonical_confusable_label'] is None
-        assert result['beautiful_canonical_confusable_label'] is None
+        assert result['normalized_canonical_label'] is None
+        assert result['beautiful_canonical_label'] is None
 
 
 @pytest.mark.parametrize('label,script', [


### PR DESCRIPTION
> We should have a rule that the canonical field for a grapheme / label / name will always be normalized. If the canonical for some grapheme / label / name would not be normalized then we should say the canonical is null then.